### PR TITLE
Add Scala 2.13 support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
 import ReleaseTransformations._
 
 lazy val baseSettings = Seq(
-  scalaVersion := "2.12.8",
-  crossScalaVersions := Seq(scalaVersion.value, "2.11.12"),
+  scalaVersion := "2.13.0",
+  crossScalaVersions := Seq(scalaVersion.value, "2.12.8", "2.11.12"),
   organization := "com.madgag.scala-git",
   scmInfo := Some(ScmInfo(
     url("https://github.com/rtyley/scala-git"),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   val eclipseJgit = "org.eclipse.jgit" % "org.eclipse.jgit" % "4.0.1.201506240215-r"
   val jgit = eclipseJgit
 
-  val scalatest = "org.scalatest" %% "scalatest" % "3.0.4"
+  val scalatest = "org.scalatest" %% "scalatest" % "3.0.8"
 
   val madgagCompress = "com.madgag" % "util-compress" % "1.33"
 

--- a/scala-git/src/main/scala/com/madgag/diff/MapDiff.scala
+++ b/scala-git/src/main/scala/com/madgag/diff/MapDiff.scala
@@ -1,5 +1,7 @@
 package com.madgag.diff
 
+import scala.collection.immutable.Map
+
 object MapDiff {
   def apply[K,V](before: Map[K,V], after: Map[K,V]): MapDiff[K,V] =
     MapDiff(Map(Before -> before, After -> after))
@@ -10,14 +12,14 @@ case class MapDiff[K, V](beforeAndAfter: Map[BeforeAndAfter, Map[K,V]]) {
   lazy val commonElements: Set[K] = beforeAndAfter.values.map(_.keySet).reduce(_ intersect _)
 
   lazy val only: Map[BeforeAndAfter, Map[K,V]] =
-    beforeAndAfter.mapValues(_.filterKeys(!commonElements(_)))
+    beforeAndAfter.mapValues(_.filterKeys(!commonElements(_)).toMap).toMap
 
   lazy val (unchanged, changed) =
     commonElements.partition(k => beforeAndAfter(Before)(k) == beforeAndAfter(After)(k))
 
-  lazy val unchangedMap: Map[K,V] = beforeAndAfter(Before).filterKeys(unchanged)
+  lazy val unchangedMap: Map[K,V] = beforeAndAfter(Before).filterKeys(unchanged).toMap
 
   lazy val changedMap: Map[K,Map[BeforeAndAfter, V]] =
-    changed.map(k => k -> beforeAndAfter.mapValues(_(k))).toMap
+    changed.map(k => k -> beforeAndAfter.mapValues(_(k)).toMap).toMap
 
 }

--- a/scala-git/src/main/scala/com/madgag/git/model/Tree.scala
+++ b/scala-git/src/main/scala/com/madgag/git/model/Tree.scala
@@ -42,7 +42,7 @@ object Tree {
       entries += Entry(treeParser)
       treeParser.next()
     }
-    entries
+    entries.toSeq
   }
 
   case class Entry(name: FileName, fileMode: FileMode, objectId: ObjectId) extends Ordered[Entry] {

--- a/scala-git/src/main/scala/com/madgag/git/package.scala
+++ b/scala-git/src/main/scala/com/madgag/git/package.scala
@@ -262,7 +262,7 @@ package object git {
   }
 
   def diff(trees: RevTree*)(implicit reader: ObjectReader): Seq[DiffEntry] =
-    DiffEntry.scan(walk(trees: _*)(TreeFilter.ANY_DIFF)).asScala
+    DiffEntry.scan(walk(trees: _*)(TreeFilter.ANY_DIFF)).asScala.toSeq
 
   def allBlobsUnder(tree: RevTree)(implicit reader: ObjectReader): Set[ObjectId] =
     tree.walk().map(_.getObjectId(0)).toSet

--- a/scala-git/src/test/scala/com/madgag/git/ReachableBlobSpec.scala
+++ b/scala-git/src/test/scala/com/madgag/git/ReachableBlobSpec.scala
@@ -19,6 +19,7 @@ package com.madgag.git
 import org.scalatest.{FlatSpec, Matchers}
 import com.madgag.git.test._
 
+import scala.language.postfixOps
 
 class ReachableBlobSpec extends FlatSpec with Matchers {
 

--- a/scala-git/src/test/scala/com/madgag/git/RichTreeWalkSpec.scala
+++ b/scala-git/src/test/scala/com/madgag/git/RichTreeWalkSpec.scala
@@ -43,7 +43,7 @@ class RichTreeWalkSpec extends FlatSpec with Matchers {
 
      fileNameList should have size 6
 
-     fileNameList.groupBy(identity).mapValues(_.size) should contain ("zero" -> 2)
+     fileNameList.groupBy(identity).mapValues(_.size).toMap should contain ("zero" -> 2)
    }
 
    it should "implement withFilter" in {


### PR DESCRIPTION
This adds Scala 2.13 to the `crossScalaVersions` and adds required changes to the code that enables cross compilation between Scala 2.1{1,2,3}.

It would be great to get this merged and release a version of scala-git that could be used across all of these Scala versions. 