### PR TITLE
Switch to Scala 3 - fails (due to `ClassLoaderLayeringStrategy`?)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import sbtversionpolicy.withsbtrelease.ReleaseVersion
 import Dependencies.*
 
 lazy val artifactProducingProjectSettings = Seq(
-  scalaVersion := "2.13.16",
+  scalaVersion := "3.3.5",
   organization := "com.madgag.scala-git",
   licenses := Seq(License.Apache2),
   scalacOptions ++= Seq("-deprecation", "-unchecked", "-release:11"),


### PR DESCRIPTION
Switching to Scala 3 (from Scala 2.13.16) [fails](https://github.com/rtyley/scala-git/actions/runs/13183209196/job/36798954929?pr=14#step:4:134):

```
[error] Test suite com.madgag.git.ReachableBlobSpec failed with java.lang.NoClassDefFoundError: com/madgag/compress/CompressUtil$.
[error] This may be due to the ClassLoaderLayeringStrategy (ScalaLibrary) used by your task.
[error] To improve performance and reduce memory, sbt attempts to cache the class loaders used to load the project dependencies.
[error] The project class files are loaded in a separate class loader that is created for each test run.
[error] The test class loader accesses the project dependency classes using the cached project dependency classloader.
[error] With this approach, class loading may fail under the following conditions:
[error] 
[error]  * Dependencies use reflection to access classes in your project's classpath.
[error]    Java serialization/deserialization may cause this.
[error]  * An open package is accessed across layers. If the project's classes access or extend
[error]    jvm package private classes defined in a project dependency, it may cause an IllegalAccessError
[error]    because the jvm enforces package private at the classloader level.
[error] 
[error] These issues, along with others that were not enumerated above, may be resolved by changing the class loader layering strategy.
[error] The Flat and ScalaLibrary strategies bundle the full project classpath in the same class loader.
[error] To use one of these strategies, set the ClassLoaderLayeringStrategy key
[error] in your configuration, for example:
[error] 
[error] set scala-git / Test / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.ScalaLibrary
[error] set scala-git / Test / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.Flat
[error] 
[error] See ClassLoaderLayeringStrategy.scala for the full list of options.
```

Unfortunately, even if we follow the advice of the setting the `ClassLoaderLayeringStrategy`, the build still fails:

* https://github.com/rtyley/scala-git/pull/15
* https://github.com/rtyley/scala-git/pull/16

Forking also fails:

* https://github.com/rtyley/scala-git/pull/17

See also:

* https://github.com/sbt/sbt/pull/4476